### PR TITLE
Stack.v now has parametrized depth expressed as number of bits in sta…

### DIFF
--- a/verilog/stack.v
+++ b/verilog/stack.v
@@ -1,17 +1,18 @@
 `include "common.h"
 
-module stack( 
-  input wire clk,
+module stack
+  #(parameter DEPTH=4)
+  (input wire clk,
   /* verilator lint_off UNUSED */
   input wire resetq,
   /* verilator lint_on UNUSED */
-  input wire [3:0] ra,
+  input wire [DEPTH-1:0] ra,
   output wire [`WIDTH-1:0] rd,
   input wire we,
-  input wire [3:0] wa,
+  input wire [DEPTH-1:0] wa,
   input wire [`WIDTH-1:0] wd);
 
-  reg [`WIDTH-1:0] store[0:15];
+  reg [`WIDTH-1:0] store[0:(2**DEPTH)-1];
 
   always @(posedge clk)
     if (we)


### PR DESCRIPTION
…ck pointer.  Default to 4; when building for Spartan 6 there is no penalty for extending to 5 [32 elements] if desired.
