### PR TITLE
parametrized j1.v to use global DEPTH to configure stacks to any powe…

### DIFF
--- a/verilog/common.h
+++ b/verilog/common.h
@@ -1,3 +1,3 @@
 `default_nettype none
 `define WIDTH 32
-
+`define DEPTH 4


### PR DESCRIPTION
…r-of-two depth.

added DEPTH global to common.h
added NOSHIFTER global parameter to configure the core without the barrel shifter, cutting the core size by approximately 1/2 (shifts by 1 are substituted instead).
-by default the CPU will build as before, but there are convenient options to have.

I hope you find these contributions helpful
